### PR TITLE
Model类型解析

### DIFF
--- a/RestDocCore/src/main/java/cn/willingxyz/restdoc/core/config/RestDocConfig.java
+++ b/RestDocCore/src/main/java/cn/willingxyz/restdoc/core/config/RestDocConfig.java
@@ -19,6 +19,10 @@ public class RestDocConfig {
      * 把Tag的描述显示为tag Name。默认tag name为类的名字，如果该值为true，则使用javadoc的第一行作为name
      */
     private boolean _tagDescriptionAsName = false;
+    /**
+     * 将JavaDoc的注释作为类的名称
+     */
+    private boolean _resolveJavaDocAsTypeName;
 
     /**
      * 如果controller里没有方法，则不显示该controller

--- a/RestDocCore/src/main/java/cn/willingxyz/restdoc/core/parse/impl/TypeNameParser.java
+++ b/RestDocCore/src/main/java/cn/willingxyz/restdoc/core/parse/impl/TypeNameParser.java
@@ -1,7 +1,9 @@
 package cn.willingxyz.restdoc.core.parse.impl;
 
 import cn.willingxyz.restdoc.core.parse.ITypeNameParser;
+import com.github.therapi.runtimejavadoc.RuntimeJavadoc;
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 import lombok.var;
 
 import java.lang.reflect.Type;
@@ -10,6 +12,7 @@ import java.util.*;
 /**
  * 按照调用parse的顺序简化类名。
  */
+@Slf4j
 public class TypeNameParser implements ITypeNameParser {
 
     private Map<String, Type> _typeNameToType = new HashMap<>();
@@ -72,8 +75,7 @@ public class TypeNameParser implements ITypeNameParser {
         return builder.toString();
     }
 
-    private SimpleResult simpleName(String name, int complexity)
-    {
+    private SimpleResult simpleName(String name, int complexity) {
         var simpleResult = new SimpleResult();
         var dotCount = getDotCount(name);
         if (dotCount < complexity) {
@@ -91,8 +93,7 @@ public class TypeNameParser implements ITypeNameParser {
     }
 
     @Data
-    public static class SimpleResult
-    {
+    public static class SimpleResult {
         private String _result;
         private int _consumeComplexity;
     }
@@ -101,13 +102,10 @@ public class TypeNameParser implements ITypeNameParser {
         return name.length() - name.replaceAll("\\.", "").length();
     }
 
-    private int indexOf(String str, int count)
-    {
+    private int indexOf(String str, int count) {
         int currentCount = 0;
-        for (int i = 0; i < str.length(); ++i)
-        {
-            if (str.charAt(i) == '.')
-            {
+        for (int i = 0; i < str.length(); ++i) {
+            if (str.charAt(i) == '.') {
                 currentCount++;
                 if (currentCount == count)
                     return i;
@@ -126,14 +124,16 @@ public class TypeNameParser implements ITypeNameParser {
         int rightAngleBracketIndex = typeName.lastIndexOf('>');
 
         if (leftAngleBracketIndex == -1 || rightAngleBracketIndex == -1) {
-            addItem(items, typeName);
+            addItem(items, getTypeName(typeName));
             return;
         }
         String rawType = typeName.substring(0, leftAngleBracketIndex);
-        addItem(items, rawType);
+        addItem(items, getTypeName(rawType));
         items.add("<");
         String typeArgument = typeName.substring(leftAngleBracketIndex + 1, rightAngleBracketIndex);
-        splitTypeName(typeArgument, items);
+        for (String typeArg : typeArgument.split(",")) {
+            splitTypeName(typeArg, items);
+        }
         items.add(">");
     }
 
@@ -150,4 +150,25 @@ public class TypeNameParser implements ITypeNameParser {
                 items.add(",");
         }
     }
+
+    /**
+     * 将Model解析为注释
+     *
+     * @param className Model类型名称
+     * @return 解析完成的类型名称
+     */
+    private String getTypeName(String className) {
+        if (className == null || (className = className.trim()).equals("")) return className;
+        Class<?> type;
+        try {
+            type = Class.forName(className);
+        } catch (ClassNotFoundException e) {
+            log.error(e.getMessage(), e);
+            return className;
+        }
+        String typeName = type.getTypeName();
+        String classComment = RuntimeJavadoc.getJavadoc(type).getComment().toString();
+        return (classComment != null && !classComment.trim().equals("")) ? classComment : typeName;
+    }
+
 }

--- a/RestDocCore/src/main/java/cn/willingxyz/restdoc/core/parse/impl/TypeNameParser.java
+++ b/RestDocCore/src/main/java/cn/willingxyz/restdoc/core/parse/impl/TypeNameParser.java
@@ -3,6 +3,7 @@ package cn.willingxyz.restdoc.core.parse.impl;
 import cn.willingxyz.restdoc.core.parse.ITypeNameParser;
 import com.github.therapi.runtimejavadoc.RuntimeJavadoc;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.var;
 
@@ -13,9 +14,15 @@ import java.util.*;
  * 按照调用parse的顺序简化类名。
  */
 @Slf4j
+@NoArgsConstructor
 public class TypeNameParser implements ITypeNameParser {
 
     private Map<String, Type> _typeNameToType = new HashMap<>();
+    private boolean resolveJavaDocAsTypeName;
+
+    public TypeNameParser(boolean resolveJavaDocAsTypeName) {
+        this.resolveJavaDocAsTypeName = resolveJavaDocAsTypeName;
+    }
 
     @Override
     public String parse(Type type) {
@@ -158,7 +165,7 @@ public class TypeNameParser implements ITypeNameParser {
      * @return 解析完成的类型名称
      */
     private String getTypeName(String className) {
-        if (className == null || (className = className.trim()).equals("")) return className;
+        if (!resolveJavaDocAsTypeName || className == null || (className = className.trim()).equals("")) return className;
         Class<?> type;
         try {
             type = Class.forName(className);

--- a/RestDocSpring/src/main/java/cn/willingxyz/restdoc/spring/SpringMethodParser.java
+++ b/RestDocSpring/src/main/java/cn/willingxyz/restdoc/spring/SpringMethodParser.java
@@ -19,7 +19,7 @@ public class SpringMethodParser implements IMethodParser {
         setDeprecated(method, pathModel);
 
         var controllerRequestMapping = method.getDeclaringClass().getAnnotation(RequestMapping.class);
-        String[] controllerPaths = null;
+        String[] controllerPaths = new String[]{"/"};
         RequestMethod[] controllerRequestMethods = null;
         if (controllerRequestMapping != null) {
             controllerPaths = combinePath(controllerRequestMapping.path(), controllerRequestMapping.value());

--- a/RestDocSpringExamples/src/main/java/cn/willingxyz/restdoc/spring/examples/parameter/MultipartGenericParameter.java
+++ b/RestDocSpringExamples/src/main/java/cn/willingxyz/restdoc/spring/examples/parameter/MultipartGenericParameter.java
@@ -1,0 +1,13 @@
+package cn.willingxyz.restdoc.spring.examples.parameter;
+
+import lombok.Data;
+
+/**
+ * @author cweijan
+ * @version 2019/10/29 11:23
+ */
+@Data
+public class MultipartGenericParameter<T,E> {
+    private T _t;
+    private E _e;
+}

--- a/RestDocSpringExamples/src/main/java/cn/willingxyz/restdoc/spring/examples/parameter/ParameterController.java
+++ b/RestDocSpringExamples/src/main/java/cn/willingxyz/restdoc/spring/examples/parameter/ParameterController.java
@@ -85,4 +85,12 @@ public class ParameterController {
     {
     }
 
+    /**
+     * 双重泛型参数
+     */
+    @PostMapping("/body/generic/multi")
+    public void bodyGenericMulti(@RequestBody MultipartGenericParameter<Integer,ParameterA> parameter)
+    {
+    }
+
 }

--- a/RestDocSpringExamples/src/main/java/cn/willingxyz/restdoc/spring/examples/path/PathController.java
+++ b/RestDocSpringExamples/src/main/java/cn/willingxyz/restdoc/spring/examples/path/PathController.java
@@ -1,0 +1,21 @@
+package cn.willingxyz.restdoc.spring.examples.path;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 路径测试接口
+ * Controller如果没有RequestMapping注解则默认为路径为/
+ * @author cweijan
+ * @version 2019/10/29 11:02
+ */
+@RestController
+public class PathController {
+
+    @RequestMapping("/none_controller_path")
+    public void noneControlerPath(){
+
+    }
+
+
+}

--- a/RestDocSpringSwagger2/src/main/java/cn/willingxyz/restdoc/springswagger2/SpringSwagger2Configuration.java
+++ b/RestDocSpringSwagger2/src/main/java/cn/willingxyz/restdoc/springswagger2/SpringSwagger2Configuration.java
@@ -22,6 +22,7 @@ import org.springframework.context.annotation.Primary;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 @Configuration
@@ -58,6 +59,9 @@ public class SpringSwagger2Configuration {
     }
 
     private List<SwaggerGeneratorConfig.ServerInfo> convertServers(List<RestDocConfig.Server> servers) {
+        if(servers==null || servers.size()<=0){
+            return Collections.singletonList(SwaggerGeneratorConfig.ServerInfo.builder().description("server").url("/").build());
+        }
         List<SwaggerGeneratorConfig.ServerInfo> serverInfos = new ArrayList<>();
         for (RestDocConfig.Server server :servers)
         {

--- a/RestDocSpringSwagger3/src/main/java/cn/willingxyz/restdoc/springswagger3/SpringSwagger3Configuration.java
+++ b/RestDocSpringSwagger3/src/main/java/cn/willingxyz/restdoc/springswagger3/SpringSwagger3Configuration.java
@@ -21,6 +21,7 @@ import org.springframework.context.annotation.Configuration;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 @Configuration
@@ -57,6 +58,9 @@ public class SpringSwagger3Configuration {
     }
 
     private List<SwaggerGeneratorConfig.ServerInfo> convertServers(List<RestDocConfig.Server> servers) {
+        if(servers==null || servers.size()<=0){
+            return Collections.singletonList(SwaggerGeneratorConfig.ServerInfo.builder().description("server").url("/").build());
+        }
         List<SwaggerGeneratorConfig.ServerInfo> serverInfos = new ArrayList<>();
         for (RestDocConfig.Server server :servers)
         {

--- a/RestDocSpringSwagger3/src/main/java/cn/willingxyz/restdoc/springswagger3/SpringSwagger3Configuration.java
+++ b/RestDocSpringSwagger3/src/main/java/cn/willingxyz/restdoc/springswagger3/SpringSwagger3Configuration.java
@@ -47,8 +47,9 @@ public class SpringSwagger3Configuration {
                 .servers(convertServers(restDocConfig.getServers()))
                 .swaggerTypeInspector(new PrimitiveSwaggerTypeInspector())
                 .typeInspector(new JavaTypeInspector())
-                .typeNameParser(new TypeNameParser())
+                .typeNameParser(new TypeNameParser(restDocConfig.isResolveJavaDocAsTypeName()))
                 .tagDescriptionAsName(restDocConfig.isTagDescriptionAsName())
+                .resolveJavaDocAsTypeName(restDocConfig.isResolveJavaDocAsTypeName())
                 .hideEmptyController(restDocConfig.isHideEmptyController())
                 .build();
         config.getControllerResolvers().add(new SpringControllerResolver(restDocConfig.getPackages()));

--- a/RestDocSwagger3/src/main/java/cn/willingxyz/restdoc/swagger3/Swagger3RestDocGenerator.java
+++ b/RestDocSwagger3/src/main/java/cn/willingxyz/restdoc/swagger3/Swagger3RestDocGenerator.java
@@ -95,7 +95,8 @@ public class Swagger3RestDocGenerator implements IRestDocGenerator {
         for (var controller : rootModel.getControllers()) {
             var tag = new Tag();
             tag.setName(getTagName(controller));
-            tag.setDescription(controller.getDescription());
+            if(!_config.isResolveJavaDocAsTypeName())
+                tag.setDescription(controller.getDescription());
             openApi.addTagsItem(tag);
         }
     }

--- a/RestDocSwaggerCommon/src/main/java/cn/willingxyz/restdoc/swagger/common/SwaggerGeneratorConfig.java
+++ b/RestDocSwaggerCommon/src/main/java/cn/willingxyz/restdoc/swagger/common/SwaggerGeneratorConfig.java
@@ -20,6 +20,10 @@ public class SwaggerGeneratorConfig {
      */
     private boolean _tagDescriptionAsName = false;
     /**
+     * 将JavaDoc的注释作为类的名称
+     */
+    private boolean _resolveJavaDocAsTypeName = false;
+    /**
      * 如果controller里没有方法，则不显示该controller
      */
     private boolean _hideEmptyController = false;


### PR DESCRIPTION
- 将Model类型由名称解析为JavaDoc的注释
- 接口如果配置的注解是RequestMapping改为只显示Get和Post(目前是显示8个所有请求方式)
![20191029115534](https://user-images.githubusercontent.com/27798227/67736557-0c711080-fa43-11e9-88dc-40ae0dca28d1.png)

![image](https://user-images.githubusercontent.com/27798227/67736678-6eca1100-fa43-11e9-8ac0-d92feb2ea688.png)
