### PR TITLE
修复不安全反射提醒与example无法显示问题

### DIFF
--- a/RestDocCore/src/main/java/cn/willingxyz/restdoc/core/parse/impl/AbstractMethodParameterParser.java
+++ b/RestDocCore/src/main/java/cn/willingxyz/restdoc/core/parse/impl/AbstractMethodParameterParser.java
@@ -3,6 +3,7 @@ package cn.willingxyz.restdoc.core.parse.impl;
 import cn.willingxyz.restdoc.core.models.ParameterModel;
 import cn.willingxyz.restdoc.core.models.TypeContext;
 import cn.willingxyz.restdoc.core.config.AbstractRestDocParseConfigAware;
+import cn.willingxyz.restdoc.core.parse.utils.ParamUtils;
 import com.github.therapi.runtimejavadoc.ParamJavadoc;
 import cn.willingxyz.restdoc.core.parse.IMethodParameterParser;
 import cn.willingxyz.restdoc.core.parse.utils.FormatUtils;
@@ -49,7 +50,7 @@ public abstract class AbstractMethodParameterParser extends AbstractRestDocParse
     }
 
     protected String getParameterName(Parameter parameter) {
-        return parameter.getName();
+        return ParamUtils.discoverParameterName(parameter);
     }
 
     protected abstract ParameterModel.ParameterLocation getParameterLocation(Parameter parameter, Type actualParamType);

--- a/RestDocCore/src/main/java/cn/willingxyz/restdoc/core/parse/postprocessor/impl/EnumPostProcessor.java
+++ b/RestDocCore/src/main/java/cn/willingxyz/restdoc/core/parse/postprocessor/impl/EnumPostProcessor.java
@@ -13,7 +13,6 @@ import cn.willingxyz.restdoc.core.parse.utils.ReflectUtils;
 import cn.willingxyz.restdoc.core.parse.utils.TextUtils;
 import com.github.therapi.runtimejavadoc.RuntimeJavadoc;
 import com.google.auto.service.AutoService;
-import javafx.beans.property.StringProperty;
 import lombok.var;
 
 import java.lang.reflect.Method;

--- a/RestDocCore/src/main/java/cn/willingxyz/restdoc/core/parse/utils/ParamUtils.java
+++ b/RestDocCore/src/main/java/cn/willingxyz/restdoc/core/parse/utils/ParamUtils.java
@@ -1,0 +1,43 @@
+package cn.willingxyz.restdoc.core.parse.utils;
+
+import java.lang.reflect.Parameter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * @author cweijan
+ * @since 2019/12/07 20:13
+ */
+public class ParamUtils {
+
+    private static Map<Parameter, String> parameterNameMap = new HashMap<>();
+
+    /**
+     * 缓存参数名称
+     * @param parameter 参数实体
+     * @param parameterName 参数实际名称
+     */
+    public static void cacheParameterName(Parameter parameter, String parameterName) {
+        if (parameter == null) return;
+        parameterNameMap.put(parameter, parameterName);
+
+    }
+
+    /**
+     * 从缓存的map寻找参数名
+     */
+    public static String discoverParameterName(Parameter parameter) {
+        if (parameter == null) return null;
+
+        String parameterName = parameterNameMap.get(parameter);
+        if (parameterName != null) {
+            parameterNameMap.remove(parameter);
+        } else {
+            parameterName = parameter.getName();
+        }
+        return parameterName;
+
+    }
+
+}

--- a/RestDocSwagger3/src/main/java/cn/willingxyz/restdoc/swagger3/Swagger3RestDocGenerator.java
+++ b/RestDocSwagger3/src/main/java/cn/willingxyz/restdoc/swagger3/Swagger3RestDocGenerator.java
@@ -371,6 +371,7 @@ public class Swagger3RestDocGenerator implements IRestDocGenerator {
 
         for (var propertyModel : propertyModels) {
             var schema = generateSchema(enums, propertyModel.getDescription(), propertyModel.getPropertyType(), propertyModel.getChildren(), openAPI);
+            schema.setExample(propertyModel.getExample());
 //            schema.setRequired(propertyModels.stream().filter(o -> o.isRequired()).map(o -> o.getName()).collect(Collectors.toList()));
             schemas.put(propertyModel.getName(), schema);
         }


### PR DESCRIPTION
2019/12/9: 同时修复了example不能显示的问题, 现在在解析阶段的时候有example, 在转换成openapi实体时没有进行赋值